### PR TITLE
Tune virtuoso

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@ continuous integration and continuous deployment services for
 genenetwork2, genenetwork3 and several other associated projects.
 
 To build and install the container, you will need the
-guix-bioinformatics and guix-forge channels. Once these channels are
+[[https://gitlab.com/genenetwork/guix-bioinformatics][guix-bioinformatics]] and [[https://git.systemreboot.net/guix-forge/][guix-forge]] channels. Once these channels are
 pulled and available, on /penguin2/, run
 #+BEGIN_SRC shell
 $ ./genenetwork-development-deploy.sh

--- a/genenetwork-development.scm
+++ b/genenetwork-development.scm
@@ -1061,7 +1061,11 @@ reverse proxy tissue."
                    (service redis-service-type)
                    (service virtuoso-service-type
                             (virtuoso-configuration
+			     (number-of-buffers 4000000)
+			     (maximum-dirty-buffers 3000000)
+			     ;; virtuoso-port
                              (server-port 9081)
+			     ;; sparql-port: 9082
                              (http-server-port %virtuoso-sparql-port)))
                    (service genenetwork-service-type
                             (genenetwork-configuration

--- a/public-sparql.scm
+++ b/public-sparql.scm
@@ -52,7 +52,9 @@ SPARQL endpoint is listening on."
   (services (cons* (service virtuoso-service-type
                             (virtuoso-configuration
                              (server-port %virtuoso-port)
-                             (http-server-port %sparql-port)))
+                             (http-server-port %sparql-port)
+			     (number-of-buffers 4000000)
+			     (maximum-dirty-buffers 3000000)))
                    (service nginx-service-type
                             (nginx-configuration
                              (server-blocks


### PR DESCRIPTION
This PR increases the threshold for number-of-buffers and maximum-dirty-buffers:
- number-of-buffers: 4000000
- maximum-dirty-buffers: 3000000

The above is tuned for [48 GB](https://vos.openlinksw.com/owiki/wiki/VOS/VirtRDFPerformanceTuning) of memory which is better than the default.

Once in a while, particularly when we delete a graph before running an upload, we run out of memory and we have locks.  The error from our log files reads as follows:

```
09:12:34 * Monitor: Locks are held for a long time
09:15:39 * Monitor: Many lock waits
09:17:39 * Monitor: Many lock waits
09:17:47 * Monitor: Locks are held for a long time
09:19:40 * Monitor: Many lock waits
09:21:40 * Monitor: Many lock waits
09:22:14 * Monitor: Locks are held for a long time
09:28:05 * Monitor: Locks are held for a long time
09:29:32 * Monitor: Low query memory limit, try to increase MaxQueryMem
09:53:12 * Monitor: Low query memory limit, try to increase MaxQueryMem
```

When there are locks held for a long time, the virtuoso server stops responding to HTTP requests, and as such, uploads using the the sparql endpoint don't work.  A [work-around](https://vos.openlinksw.com/owiki/wiki/VOS/VirtTipsAndTricksGuideNotRespondingHTTP) is to run `txn_killall()` to kill any pending transactions which may enable the server to start responding to HTTP requests again.
